### PR TITLE
Misc. SPEC fixes

### DIFF
--- a/marshal-configs/spec17-intrate-test.json
+++ b/marshal-configs/spec17-intrate-test.json
@@ -10,6 +10,42 @@
     {
       "name": "500.perlbench_r",
       "command": "./intrate.sh 500.perlbench_r --copies 4"
+    },
+    {
+      "name": "502.gcc_r",
+      "command": "./intrate.sh 502.gcc_r --copies 4"
+    },
+    {
+      "name": "505.mcf_r",
+      "command": "./intrate.sh 505.mcf_r --copies 4"
+    },
+    {
+      "name": "520.omnetpp_r",
+      "command": "./intrate.sh 520.omnetpp_r --copies 4"
+    },
+    {
+      "name": "523.xalancbmk_r",
+      "command": "./intrate.sh 523.xalancbmk_r --copies 4"
+    },
+    {
+      "name": "525.x264_r",
+      "command": "./intrate.sh 525.x264_r --copies 4"
+    },
+    {
+      "name": "531.deepsjeng_r",
+      "command": "./intrate.sh 531.deepsjeng_r --copies 4"
+    },
+    {
+      "name": "541.leela_r",
+      "command": "./intrate.sh 541.leela_r --copies 4"
+    },
+    {
+      "name": "548.exchange2_r",
+      "command": "./intrate.sh 548.exchange2_r --copies 4"
+    },
+    {
+      "name": "557.xz_r",
+      "command": "./intrate.sh 557.xz_r --copies 4"
     }
   ]
 }

--- a/marshal-configs/spec17-intspeed-test-600.json
+++ b/marshal-configs/spec17-intspeed-test-600.json
@@ -2,7 +2,7 @@
   "name" : "spec17-intspeed-test",
   "base" : "br-base.json",
   "workdir" : "..",
-  "host-init" : "build-intspeed-test.sh test",
+  "host-init" : "build-intspeed.sh test",
   "overlay" : "speckle/build/overlay/intspeed/test",
   "rootfs-size" : "3GiB",
   "outputs" : ["/output"],

--- a/marshal-configs/spec17-intspeed-test.json
+++ b/marshal-configs/spec17-intspeed-test.json
@@ -2,7 +2,7 @@
   "name" : "spec17-intspeed-test",
   "base" : "br-base.json",
   "workdir" : "..",
-  "host-init" : "build-intspeed-test.sh test",
+  "host-init" : "build-intspeed.sh test",
   "overlay" : "speckle/build/overlay/intspeed/test",
   "rootfs-size" : "3GiB",
   "outputs" : ["/output"],


### PR DESCRIPTION
Building the `intspeed` test workloads results in a failure since there is no `-test` script. Additionally, this makes the `intrate` json use all sub-tests.